### PR TITLE
Use podman-docker for Fedora 31+

### DIFF
--- a/modules/ROOT/pages/setup.adoc
+++ b/modules/ROOT/pages/setup.adoc
@@ -17,7 +17,7 @@ The following CLI tools are required for running the exercises in this tutorial.
 
 | `Docker`
 | https://docs.docker.com/docker-for-mac/install[Docker for Mac]
-| `dnf install docker`
+| `dnf install podman-docker`
 | https://docs.docker.com/docker-for-windows/install[Docker for Windows]
 
 | `kubectl {kubernetes-version}`


### PR DESCRIPTION
On Fedora 31 docker don't work as cgroups v2 is enabled by default.

Podman-docker package exists and work without any problems. We should advise using it as this is RH product.